### PR TITLE
Fix: Enforce strict 0-255 range in IP address validation

### DIFF
--- a/src/validator.ts
+++ b/src/validator.ts
@@ -139,8 +139,8 @@ export class EnvValidator {
         break;
 
       case "ip":
-        if (!/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/.test(String(value))) {
-          throw new Error("Must be a valid IP address");
+        if (!/^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(String(value))) {
+           throw new Error("Must be a valid IP address");
         }
         break;
       case "port":


### PR DESCRIPTION
This PR fixes a logical bug in the EnvValidator where the IP address validation was too permissive.

**The Issue**: The previous regex (?:[0-9]{1,3}\.){3}[0-9]{1,3} validated the format (three dots and digits) but did not validate the value. It allowed invalid IP addresses where octets exceeded 255 (e.g., 999.999.999.999 or 300.1.1.1).

**The Fix**: I have updated the regex to strictly enforce IPv4 standards. The new pattern ensures that every octet falls within the valid range of 0 to 255.

Examples:
1. 192.168.1.1 -> Pass
2. 255.255.255.255 -> Pass
3. 256.0.0.1 -> Fail (Previously Passed)
4. 999.999.999.999 -> Fail (Previously Passed)