### PR TITLE
fix: merge process.env with .env file so loadEnv works without a .env…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,8 @@ export function validateEnv(
   schema: SchemaDefinition,
   options?: { strict?: boolean; path?: string }
 ) {
-  const env = dotenv.config({debug: false, path: options?.path}).parsed || {};
+  const fileEnv = dotenv.config({ debug: false, path: options?.path }).parsed || {};
+  const env = { ...process.env, ...fileEnv };
   const validator = new EnvValidator(schema, options);
   return validator.validate(env);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,7 +21,9 @@ export function loadEnv<S extends SchemaDefinition>(
   schema: S,
   options?: { strict?: boolean; includeRaw?: boolean; includeSensitive?: boolean; path?: string }
 ): InferEnv<S> {
-  const env = dotenv.config({debug: false, path: options?.path}).parsed || {};
+  const fileEnv = dotenv.config({ debug: false, path: options?.path }).parsed || {};
+  const env = { ...process.env, ...fileEnv };
+
   const validator = new EnvValidator(schema, options);
   return validator.validate(env) as InferEnv<S>;
 }


### PR DESCRIPTION
loadEnv and validateEnv only used dotenv.config().parsed, which is undefined when no .env file exists. Production platforms (Vercel, Railway, Docker, AWS Lambda) inject vars directly into process.env, so validation always failed there.

Now process.env is used as the base with .env file values layered on top, matching the standard dotenv precedence while supporting platform-injected variables.

Fixes #26