### PR TITLE
feat: support encrypted properties inside envPrefix object groups

### DIFF
--- a/__tests__/cli/encryption-commands.test.ts
+++ b/__tests__/cli/encryption-commands.test.ts
@@ -455,7 +455,7 @@ describe("status: encryption status reporting", () => {
       const value = parsed[key];
       if (!value) {
         results[key] = "missing";
-      } else if (rule.encrypted && isEncryptedValue(value)) {
+      } else if ("encrypted" in rule && rule.encrypted && isEncryptedValue(value)) {
         results[key] = "encrypted";
       } else {
         results[key] = "plaintext";

--- a/__tests__/grouped-encryption.test.ts
+++ b/__tests__/grouped-encryption.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Encrypted properties inside envPrefix object groups.
+ *
+ * Property-level `encrypted: true` was previously ignored end-to-end: the
+ * validator never decrypted prefixed variables, and an encrypted-looking
+ * grouped value was rejected with "schema does not declare encrypted: true"
+ * even when the property declared it.
+ */
+import { describe, test, expect, afterEach } from "vitest";
+import { defineSchema, getEncryptedEnvKeys } from "../src/schema.js";
+import { EnvValidator } from "../src/validator.js";
+import { EnvAggregateError } from "../src/errors.js";
+import { generateKeyPair, encryptEnvValue } from "../src/crypto.js";
+
+afterEach(() => {
+  delete process.env.ENVGAD_PRIVATE_KEY;
+});
+
+describe("getEncryptedEnvKeys", () => {
+  test("collects top-level and grouped encrypted keys", () => {
+    const schema = defineSchema({
+      API_KEY: { type: "string", encrypted: true },
+      PORT: { type: "number" },
+      DATABASE: {
+        type: "object",
+        properties: {
+          PWD: { type: "string", encrypted: true },
+          HOST: { type: "string" },
+        },
+      },
+      CACHE: {
+        type: "object",
+        envPrefix: "REDIS_",
+        properties: { AUTH: { type: "string", encrypted: true } },
+      },
+    });
+
+    expect(getEncryptedEnvKeys(schema)).toEqual([
+      { envKey: "API_KEY", schemaKey: "API_KEY" },
+      { envKey: "DATABASE_PWD", schemaKey: "DATABASE" },
+      { envKey: "REDIS_AUTH", schemaKey: "CACHE" },
+    ]);
+  });
+
+  test("skips grouped names that collide with explicit schema keys", () => {
+    const schema = defineSchema({
+      DATABASE: {
+        type: "object",
+        properties: { URL: { type: "string", encrypted: true } },
+      },
+      DATABASE_URL: { type: "url" },
+    });
+
+    expect(getEncryptedEnvKeys(schema)).toEqual([]);
+  });
+});
+
+describe("Validator: encrypted grouped properties", () => {
+  test("decrypts an encrypted grouped property", () => {
+    const { publicKeyHex, privateKeyHex } = generateKeyPair();
+    const schema = defineSchema({
+      DATABASE: {
+        type: "object",
+        properties: {
+          NAME: { type: "string", required: true },
+          PWD: { type: "string", required: true, encrypted: true },
+        },
+      },
+    });
+
+    const env = {
+      DATABASE_NAME: "mydb",
+      DATABASE_PWD: encryptEnvValue("supersecret", publicKeyHex, "DATABASE_PWD"),
+    };
+
+    const v = new EnvValidator(schema, { keysPath: ".nonexistent-xyz.keys" });
+    process.env.ENVGAD_PRIVATE_KEY = privateKeyHex;
+    const result = v.validate(env);
+    expect(result.DATABASE).toEqual({ NAME: "mydb", PWD: "supersecret" });
+  });
+
+  test("plaintext value for an encrypted grouped property is rejected", () => {
+    const schema = defineSchema({
+      DATABASE: {
+        type: "object",
+        properties: { PWD: { type: "string", encrypted: true } },
+      },
+    });
+
+    const v = new EnvValidator(schema, { keysPath: ".nonexistent-xyz.keys" });
+    try {
+      v.validate({ DATABASE_PWD: "plaintext-oops" });
+      throw new Error("should have thrown");
+    } catch (err: any) {
+      const agg = err as EnvAggregateError;
+      const e = agg.errors.find((x: any) => x.key === "DATABASE_PWD");
+      expect(e).toBeDefined();
+      expect(e!.message).toMatch(/Must be encrypted/);
+    }
+  });
+
+  test("allowPlaintext warns and passes the plaintext grouped value through", () => {
+    const schema = defineSchema({
+      DATABASE: {
+        type: "object",
+        properties: { PWD: { type: "string", encrypted: true } },
+      },
+    });
+
+    const originalWarn = console.warn;
+    let warned = "";
+    console.warn = (msg: string) => {
+      warned = msg;
+    };
+    try {
+      const v = new EnvValidator(schema, {
+        allowPlaintext: true,
+        keysPath: ".nonexistent-xyz.keys",
+      });
+      const result = v.validate({ DATABASE_PWD: "plaintext-ok" });
+      expect(result.DATABASE.PWD).toBe("plaintext-ok");
+      expect(warned).toContain("DATABASE_PWD");
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test("encrypted-looking grouped value without encrypted: true still errors", () => {
+    const { publicKeyHex } = generateKeyPair();
+    const schema = defineSchema({
+      DATABASE: {
+        type: "object",
+        properties: { PWD: { type: "string" } }, // not declared encrypted
+      },
+    });
+
+    const env = {
+      DATABASE_PWD: encryptEnvValue("secret", publicKeyHex, "DATABASE_PWD"),
+    };
+
+    const v = new EnvValidator(schema, { keysPath: ".nonexistent-xyz.keys" });
+    try {
+      v.validate(env);
+      throw new Error("should have thrown");
+    } catch (err: any) {
+      const agg = err as EnvAggregateError;
+      const e = agg.errors.find((x: any) => x.key === "DATABASE_PWD");
+      expect(e).toBeDefined();
+      expect(e!.message).toMatch(/does not declare encrypted/);
+    }
+  });
+
+  test("wrong key: decryption failure is reported and the group is skipped", () => {
+    const { publicKeyHex } = generateKeyPair();
+    const wrongPair = generateKeyPair();
+    const schema = defineSchema({
+      DATABASE: {
+        type: "object",
+        properties: { PWD: { type: "string", encrypted: true } },
+      },
+    });
+
+    const env = {
+      DATABASE_PWD: encryptEnvValue("secret", publicKeyHex, "DATABASE_PWD"),
+    };
+
+    const v = new EnvValidator(schema, { keysPath: ".nonexistent-xyz.keys" });
+    process.env.ENVGAD_PRIVATE_KEY = wrongPair.privateKeyHex;
+    try {
+      v.validate(env);
+      throw new Error("should have thrown");
+    } catch (err: any) {
+      const agg = err as EnvAggregateError;
+      expect(agg.errors).toHaveLength(1);
+      expect(agg.errors[0].key).toBe("DATABASE_PWD");
+    }
+  });
+
+  test("top-level encrypted fields still work alongside grouped ones", () => {
+    const { publicKeyHex, privateKeyHex } = generateKeyPair();
+    const schema = defineSchema({
+      API_KEY: { type: "string", required: true, encrypted: true },
+      DATABASE: {
+        type: "object",
+        properties: { PWD: { type: "string", required: true, encrypted: true } },
+      },
+    });
+
+    const env = {
+      API_KEY: encryptEnvValue("sk-123", publicKeyHex, "API_KEY"),
+      DATABASE_PWD: encryptEnvValue("dbpass", publicKeyHex, "DATABASE_PWD"),
+    };
+
+    const v = new EnvValidator(schema, { keysPath: ".nonexistent-xyz.keys" });
+    process.env.ENVGAD_PRIVATE_KEY = privateKeyHex;
+    const result = v.validate(env);
+    expect(result.API_KEY).toBe("sk-123");
+    expect(result.DATABASE).toEqual({ PWD: "dbpass" });
+  });
+});

--- a/__tests__/runtime.test.ts
+++ b/__tests__/runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isBun, getEnv, getRuntimeName, getRuntimeVersion } from "../src/runtime";
+import { isBun, getEnv, getRuntimeName, getRuntimeVersion } from "../src/runtime.js";
 
 describe("Runtime Detection", () => {
   it("should detect runtime correctly", () => {

--- a/docs/docs/guide/encryption.md
+++ b/docs/docs/guide/encryption.md
@@ -94,6 +94,34 @@ console.log(env.DATABASE_URL); // "postgres://user:pass@localhost/mydb"
 
 Decryption happens transparently at startup. No code changes needed beyond the schema.
 
+## Encrypted properties in object groups
+
+Properties inside [grouped object schemas](./grouping.md) can also declare `encrypted: true`. The variable is stored under its prefixed name in `.env` and decrypted transparently before being mapped into the group:
+
+```typescript
+export default defineSchema({
+  DATABASE: {
+    type: 'object',
+    properties: {
+      HOST: { type: 'string', default: 'localhost' },
+      PWD: { type: 'string', required: true, sensitive: true, encrypted: true },
+    },
+  },
+});
+```
+
+```
+DATABASE_HOST=localhost
+DATABASE_PWD=encrypted:v1:Ro4rhopWVr0w280K2ISH…
+```
+
+```typescript
+const env = loadEnv(schema);
+console.log(env.DATABASE.PWD); // decrypted plaintext
+```
+
+All CLI commands (`encrypt`, `decrypt`, `status`, `verify`, `rotate`) treat prefixed group variables like any other encrypted field.
+
 ## CLI commands
 
 | Command | Description |

--- a/src/cli/commands/decrypt.ts
+++ b/src/cli/commands/decrypt.ts
@@ -5,6 +5,7 @@ import { createInterface } from "node:readline/promises";
 import { readFileSync, writeFileSync } from "node:fs";
 import dotenv from "dotenv";
 import { decryptEnvValue, isEncryptedValue, loadPrivateKey } from "../../crypto.js";
+import { getEncryptedEnvKeys } from "../../schema.js";
 import { EncryptionKeyMissingError } from "../../errors.js";
 import { loadSchema } from "./utils.js";
 
@@ -37,8 +38,8 @@ export default function (_program: Command) {
       try {
         const schema = await loadSchema(schemaPath);
 
-        const encryptedFields = Object.keys(schema).filter(
-          (k) => schema[k].encrypted === true
+        const encryptedFields = getEncryptedEnvKeys(schema).map(
+          (e) => e.envKey
         );
 
         if (encryptedFields.length === 0) {

--- a/src/cli/commands/encrypt.ts
+++ b/src/cli/commands/encrypt.ts
@@ -4,6 +4,7 @@ import ora from "ora";
 import { readFileSync, writeFileSync, copyFileSync } from "node:fs";
 import dotenv from "dotenv";
 import { encryptEnvValue, isEncryptedValue } from "../../crypto.js";
+import { getEncryptedEnvKeys } from "../../schema.js";
 import { EncryptionKeyMissingError } from "../../errors.js";
 import { loadSchema } from "./utils.js";
 
@@ -21,8 +22,8 @@ export default function (_program: Command) {
       try {
         const schema = await loadSchema(schemaPath);
 
-        const encryptedFields = Object.keys(schema).filter(
-          (k) => schema[k].encrypted === true
+        const encryptedFields = getEncryptedEnvKeys(schema).map(
+          (e) => e.envKey
         );
 
         if (encryptedFields.length === 0) {

--- a/src/cli/commands/rotate.ts
+++ b/src/cli/commands/rotate.ts
@@ -11,6 +11,7 @@ import {
   isEncryptedValue,
   loadPrivateKey,
 } from "../../crypto.js";
+import { getEncryptedEnvKeys } from "../../schema.js";
 import { loadSchema } from "./utils.js";
 
 async function confirm(question: string): Promise<boolean> {
@@ -39,8 +40,8 @@ export default function (_program: Command) {
       try {
         const schema = await loadSchema(schemaPath);
 
-        const encryptedFields = Object.keys(schema).filter(
-          (k) => schema[k].encrypted === true
+        const encryptedFields = getEncryptedEnvKeys(schema).map(
+          (e) => e.envKey
         );
 
         if (encryptedFields.length === 0) {

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -4,6 +4,7 @@ import ora from "ora";
 import { existsSync, readFileSync } from "node:fs";
 import dotenv from "dotenv";
 import { isEncryptedValue, loadPrivateKey } from "../../crypto.js";
+import { getEncryptedEnvKeys, type SchemaRule } from "../../schema.js";
 import { loadSchema } from "./utils.js";
 
 export default function (_program: Command) {
@@ -34,9 +35,24 @@ export default function (_program: Command) {
         spinner.stop();
 
         const schemaKeys = Object.keys(schema);
-        const encryptedSchemaKeys = new Set(
-          schemaKeys.filter((k) => schema[k].encrypted)
-        );
+
+        // One row per .env variable: object groups are expanded into their
+        // prefixed property keys (e.g. DATABASE_PWD), everything else is the
+        // schema key itself.
+        const rows: { key: string; rule: SchemaRule }[] = [];
+        for (const key of schemaKeys) {
+          const rule = schema[key];
+          if (rule.type === "object" && rule.properties) {
+            const prefix = rule.envPrefix ?? `${key}_`;
+            for (const [prop, propRule] of Object.entries(rule.properties)) {
+              const envKey = `${prefix}${prop}`;
+              if (Object.prototype.hasOwnProperty.call(schema, envKey)) continue;
+              rows.push({ key: envKey, rule: propRule });
+            }
+          } else {
+            rows.push({ key, rule });
+          }
+        }
 
         console.log(chalk.bold("\nEnvironment Encryption Status"));
         console.log(chalk.dim("─".repeat(52)));
@@ -44,8 +60,7 @@ export default function (_program: Command) {
         let correctCount = 0;
         let warningCount = 0;
 
-        for (const key of schemaKeys) {
-          const rule = schema[key];
+        for (const { key, rule } of rows) {
           const value = parsed[key];
           const needsEncryption = rule.encrypted === true;
           const valueIsEncrypted = value ? isEncryptedValue(value) : false;
@@ -118,7 +133,7 @@ export default function (_program: Command) {
 
         console.log();
 
-        const encryptedTotal = encryptedSchemaKeys.size;
+        const encryptedTotal = getEncryptedEnvKeys(schema).length;
         if (warningCount > 0) {
           console.log(
             chalk.yellow(`  ${warningCount} issue(s) detected`) +
@@ -127,7 +142,7 @@ export default function (_program: Command) {
           process.exit(1);
         } else {
           console.log(
-            chalk.green(`  All ${schemaKeys.length} field(s) are correctly configured`)
+            chalk.green(`  All ${rows.length} field(s) are correctly configured`)
           );
         }
       } catch (error) {

--- a/src/cli/commands/verify.ts
+++ b/src/cli/commands/verify.ts
@@ -4,6 +4,7 @@ import ora from "ora";
 import { existsSync, readFileSync } from "node:fs";
 import dotenv from "dotenv";
 import { decryptEnvValue, isEncryptedValue, loadPrivateKey } from "../../crypto.js";
+import { getEncryptedEnvKeys } from "../../schema.js";
 import { EncryptionKeyMissingError } from "../../errors.js";
 import { loadSchema } from "./utils.js";
 
@@ -24,8 +25,8 @@ export default function (_program: Command) {
       try {
         const schema = await loadSchema(schemaPath);
 
-        const encryptedFields = Object.keys(schema).filter(
-          (k) => schema[k].encrypted === true
+        const encryptedFields = getEncryptedEnvKeys(schema).map(
+          (e) => e.envKey
         );
 
         if (encryptedFields.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,11 @@
 import { EnvValidator } from "./validator.js";
-import { defineSchema, SchemaDefinition, SchemaRule } from "./schema.js";
+import {
+  defineSchema,
+  getEncryptedEnvKeys,
+  SchemaDefinition,
+  SchemaRule,
+  EncryptedEnvKey,
+} from "./schema.js";
 import {
   EnvAggregateError,
   AggregateError,
@@ -24,6 +30,7 @@ import { isBun, getEnv, getRuntimeName, getRuntimeVersion } from "./runtime.js";
 
 export {
   defineSchema,
+  getEncryptedEnvKeys,
   EnvAggregateError,
   /** @deprecated Use `EnvAggregateError` instead. */
   AggregateError,
@@ -45,7 +52,14 @@ export {
   getRuntimeName,
   getRuntimeVersion,
 };
-export type { SchemaDefinition, SchemaRule, ExtractEnv, InferEnv, KeyPair };
+export type {
+  SchemaDefinition,
+  SchemaRule,
+  EncryptedEnvKey,
+  ExtractEnv,
+  InferEnv,
+  KeyPair,
+};
 
 export function validateEnv(
   schema: SchemaDefinition,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -44,6 +44,41 @@ export interface SchemaRule {
 
 export type SchemaDefinition = Record<string, SchemaRule>;
 
+export interface EncryptedEnvKey {
+  /** Name of the variable as it appears in the .env file / process.env. */
+  envKey: string;
+  /** Top-level schema key that owns this variable. */
+  schemaKey: string;
+}
+
+/**
+ * Enumerates the .env variable names of every field marked `encrypted: true`:
+ * top-level schema keys, plus `<prefix><PROP>` for object groups whose
+ * properties declare `encrypted: true` (grouped via `envPrefix`, defaulting
+ * to `<SCHEMA_KEY>_`).
+ */
+export function getEncryptedEnvKeys(
+  schema: SchemaDefinition
+): EncryptedEnvKey[] {
+  const keys: EncryptedEnvKey[] = [];
+  for (const [key, rule] of Object.entries(schema)) {
+    if (rule.encrypted === true) {
+      keys.push({ envKey: key, schemaKey: key });
+    }
+    if (rule.type === "object" && rule.properties) {
+      const prefix = rule.envPrefix ?? `${key}_`;
+      for (const [prop, propRule] of Object.entries(rule.properties)) {
+        if (propRule.encrypted !== true) continue;
+        const envKey = `${prefix}${prop}`;
+        // A prefixed name that collides with an explicit schema key belongs
+        // to that key, not the group.
+        if (Object.prototype.hasOwnProperty.call(schema, envKey)) continue;
+        keys.push({ envKey, schemaKey: key });
+      }
+    }
+  }
+  return keys;
+}
 
 /**
  * A type-safe way to define your environment schema.

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,4 +1,4 @@
-import { SchemaDefinition, SchemaRule } from "./schema.js";
+import { SchemaDefinition, SchemaRule, getEncryptedEnvKeys } from "./schema.js";
 import { EnvAggregateError, EncryptionKeyMissingError } from "./errors.js";
 import { decryptEnvValue, isEncryptedValue, loadPrivateKey } from "./crypto.js";
 import { getEnv } from "./runtime.js";
@@ -472,14 +472,19 @@ export class EnvValidator {
     const processedEnv: Record<string, string | undefined> = { ...env };
     const skipKeys = new Set<string>();
 
-    const encryptedSchemaKeys = Object.keys(this.schema).filter(
-      (k) => this.schema[k].encrypted
-    );
+    // Every declared encrypted variable: top-level keys plus grouped
+    // properties (e.g. DATABASE_PWD for a DATABASE group with an encrypted
+    // PWD property). For grouped entries, decryption failures skip the whole
+    // owning group via schemaKey.
+    const encryptedKeys = getEncryptedEnvKeys(this.schema);
 
-    if (encryptedSchemaKeys.length > 0) {
+    if (encryptedKeys.length > 0) {
       // Only load the private key when at least one value is already encrypted
-      const needsDecryption = encryptedSchemaKeys.some(
-        (k) => processedEnv[k] != null && processedEnv[k] !== "" && isEncryptedValue(processedEnv[k]!)
+      const needsDecryption = encryptedKeys.some(
+        ({ envKey }) =>
+          processedEnv[envKey] != null &&
+          processedEnv[envKey] !== "" &&
+          isEncryptedValue(processedEnv[envKey]!)
       );
 
       let privateKeyHex: string | null = null;
@@ -490,45 +495,46 @@ export class EnvValidator {
         }
       }
 
-      for (const key of encryptedSchemaKeys) {
-        const value = processedEnv[key];
+      for (const { envKey, schemaKey } of encryptedKeys) {
+        const value = processedEnv[envKey];
         if (value == null || value === "") continue; // handled by required check in main loop
 
         if (isEncryptedValue(value)) {
           try {
-            processedEnv[key] = decryptEnvValue(value, privateKeyHex!, key);
+            processedEnv[envKey] = decryptEnvValue(value, privateKeyHex!, envKey);
           } catch (err) {
             this.errors.push({
-              key,
+              key: envKey,
               message: err instanceof Error ? err.message : "Decryption failed",
-              rule: this.schema[key],
+              rule: this.schema[schemaKey],
             });
-            skipKeys.add(key);
+            skipKeys.add(schemaKey);
           }
         } else {
           // Plaintext value for a field that should be encrypted
           if (this.options?.allowPlaintext) {
             console.warn(
-              `[dotenv-gad] "${key}" has a plaintext value but schema declares encrypted: true. ` +
+              `[dotenv-gad] "${envKey}" has a plaintext value but schema declares encrypted: true. ` +
                 "Run: npx dotenv-gad encrypt"
             );
           } else {
             this.errors.push({
-              key,
+              key: envKey,
               message:
                 'Must be encrypted. Run: npx dotenv-gad encrypt',
-              rule: this.schema[key],
+              rule: this.schema[schemaKey],
             });
-            skipKeys.add(key);
+            skipKeys.add(schemaKey);
           }
         }
       }
     }
 
     // Flag any env value that looks encrypted but the schema doesn't declare encrypted: true
+    const declaredEncrypted = new Set(encryptedKeys.map((e) => e.envKey));
     for (const [eKey, value] of Object.entries(processedEnv)) {
-      if (skipKeys.has(eKey)) continue;
-      if (value && isEncryptedValue(value) && !this.schema[eKey]?.encrypted) {
+      if (skipKeys.has(eKey) || declaredEncrypted.has(eKey)) continue;
+      if (value && isEncryptedValue(value)) {
         this.errors.push({
           key: eKey,
           message: "Encrypted value found but schema does not declare encrypted: true",


### PR DESCRIPTION
Property-level `encrypted: true` inside object groups was accepted by the type
system but ignored end-to-end: the validator never decrypted prefixed variables,
an encrypted-looking grouped value (e.g. `DATABASE_PWD=encrypted:v1:…`) was
rejected with "schema does not declare encrypted: true" with no way to declare
it, and the CLI commands only scanned top-level schema keys.

**Encrypted group properties now work everywhere:**

- New `getEncryptedEnvKeys(schema)` helper (exported) enumerates every encrypted
  .env variable: top-level keys plus `<prefix><PROP>` for group properties.
  Prefixed names that collide with explicit schema keys belong to those keys and
  are skipped.
- The validator decrypts prefixed variables before grouping, enforces
  plaintext-on-encrypted errors (and `allowPlaintext` warnings) for group
  properties, and skips the owning group on decryption failure. Undeclared
  encrypted-looking values still error as before.
- `encrypt`, `decrypt`, `verify`, and `rotate` handle grouped secrets like any
  other field; `status` expands groups into one row per prefixed variable.
- AAD binding is unchanged: the full prefixed name (e.g. `DATABASE_PWD`) is used
  by both the CLI and the validator.

Also fixes the two pre-existing `tsc --noEmit` errors in test files, and adds an
"Encrypted properties in object groups" section to the encryption guide.

Tests: 8 new tests in `__tests__/grouped-encryption.test.ts`; full suite passes
(201 tests, 16 files) and typecheck is clean.