### PR TITLE
fix: real environment variables now take precedence over .env file values (#61)

### DIFF
--- a/__tests__/env-precedence.test.ts
+++ b/__tests__/env-precedence.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Issue #61: .env file values must not override real environment variables.
+ * Following dotenv conventions, the file provides defaults and the real
+ * environment wins, unless `override: true` is passed explicitly.
+ */
+import { describe, test, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { defineSchema, loadEnv, validateEnv } from "../src/index.js";
+import { mergeEnv } from "../src/utils.js";
+
+const TMP = join(__dirname, ".fixtures-precedence");
+const ENV_PATH = join(TMP, ".env");
+
+beforeAll(() => {
+  mkdirSync(TMP, { recursive: true });
+  writeFileSync(ENV_PATH, "PRECEDENCE_LOG_LEVEL=debug\nPRECEDENCE_FILE_ONLY=from-file\n");
+});
+afterAll(() => {
+  if (existsSync(TMP)) rmSync(TMP, { recursive: true });
+});
+afterEach(() => {
+  delete process.env.PRECEDENCE_LOG_LEVEL;
+});
+
+const schema = defineSchema({
+  PRECEDENCE_LOG_LEVEL: { type: "string", default: "info" },
+  PRECEDENCE_FILE_ONLY: { type: "string" },
+});
+
+describe("mergeEnv", () => {
+  test("runtime environment wins over file values by default", () => {
+    expect(mergeEnv({ A: "file" }, { A: "runtime" })).toEqual({ A: "runtime" });
+  });
+
+  test("file value fills in when the runtime variable is unset", () => {
+    expect(mergeEnv({ A: "file" }, {})).toEqual({ A: "file" });
+  });
+
+  test("an undefined runtime entry does not clobber a file value", () => {
+    expect(mergeEnv({ A: "file" }, { A: undefined })).toEqual({ A: "file" });
+  });
+
+  test("override: true lets file values replace runtime variables", () => {
+    expect(mergeEnv({ A: "file" }, { A: "runtime" }, true)).toEqual({
+      A: "file",
+    });
+  });
+});
+
+describe("loadEnv precedence (issue #61)", () => {
+  test("real environment variable beats the .env file value", () => {
+    process.env.PRECEDENCE_LOG_LEVEL = "error";
+    const env = loadEnv(schema, { path: ENV_PATH });
+    expect(env.PRECEDENCE_LOG_LEVEL).toBe("error");
+    expect(env.PRECEDENCE_FILE_ONLY).toBe("from-file");
+  });
+
+  test(".env file value is used when the variable is not set", () => {
+    const env = loadEnv(schema, { path: ENV_PATH });
+    expect(env.PRECEDENCE_LOG_LEVEL).toBe("debug");
+  });
+
+  test("override: true restores file-wins behavior", () => {
+    process.env.PRECEDENCE_LOG_LEVEL = "error";
+    const env = loadEnv(schema, { path: ENV_PATH, override: true });
+    expect(env.PRECEDENCE_LOG_LEVEL).toBe("debug");
+  });
+});
+
+describe("validateEnv precedence (issue #61)", () => {
+  test("real environment variable beats the .env file value", () => {
+    process.env.PRECEDENCE_LOG_LEVEL = "error";
+    const env = validateEnv(schema, { path: ENV_PATH });
+    expect(env.PRECEDENCE_LOG_LEVEL).toBe("error");
+  });
+
+  test("override: true restores file-wins behavior", () => {
+    process.env.PRECEDENCE_LOG_LEVEL = "error";
+    const env = validateEnv(schema, { path: ENV_PATH, override: true });
+    expect(env.PRECEDENCE_LOG_LEVEL).toBe("debug");
+  });
+});

--- a/docs/docs/Getting Started/usage.md
+++ b/docs/docs/Getting Started/usage.md
@@ -29,7 +29,7 @@ const env = loadEnv(schema);
 console.log(env.PORT); // number — fully typed
 ```
 
-`loadEnv` reads from both `process.env` and your `.env` file (if present). `.env` file values take priority over existing `process.env` values, but platform-injected variables (Vercel, Railway, Docker, AWS Lambda) work out of the box — no `.env` file required.
+`loadEnv` reads from both `process.env` and your `.env` file (if present). Following dotenv conventions, variables already set in the real environment take priority over `.env` file values — the file provides development defaults, and platform-injected variables (Vercel, Railway, Docker, AWS Lambda) work out of the box with no `.env` file required. Pass `override: true` if you want file values to win instead.
 
 ## Options
 
@@ -37,6 +37,7 @@ console.log(env.PORT); // number — fully typed
 - `includeRaw` — include raw values in error reports (non-sensitive by default).
 - `includeSensitive` — when used with `includeRaw` will reveal values marked sensitive (use only for local debugging).
 - `path` — path to a custom `.env` file (defaults to `.env` in cwd).
+- `override` — when true, `.env` file values replace variables already set in the real environment (default: the real environment wins).
 
 ## Using EnvValidator directly
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import {
   loadPrivateKey,
 } from "./crypto.js";
 import type { KeyPair } from "./crypto.js";
-import { readEnvFile } from "./utils.js";
+import { readEnvFile, mergeEnv } from "./utils.js";
 import { isBun, getEnv, getRuntimeName, getRuntimeVersion } from "./runtime.js";
 
 export {
@@ -68,10 +68,11 @@ export function validateEnv(
     path?: string;
     allowPlaintext?: boolean;
     keysPath?: string;
+    override?: boolean;
   }
 ) {
   const fileEnv = readEnvFile(options?.path);
-  const env = { ...process.env, ...fileEnv };
+  const env = mergeEnv(fileEnv, process.env, options?.override);
   const validator = new EnvValidator(schema, options);
   return validator.validate(env);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,6 +37,25 @@ export function readEnvFile(path?: string): Record<string, string> {
 
 
 /**
+ * Merges `.env` file values with the runtime environment. Following dotenv
+ * conventions, variables already set in the real environment win over file
+ * values — the file provides defaults. Pass `override: true` to invert this
+ * and let file values replace runtime variables.
+ */
+export function mergeEnv(
+  fileEnv: Record<string, string>,
+  runtimeEnv: Record<string, string | undefined>,
+  override?: boolean
+): Record<string, string | undefined> {
+  if (override) return { ...runtimeEnv, ...fileEnv };
+  const env: Record<string, string | undefined> = { ...fileEnv };
+  for (const [key, value] of Object.entries(runtimeEnv)) {
+    if (value !== undefined) env[key] = value;
+  }
+  return env;
+}
+
+/**
  * Loads environment variables from a `.env` file (if present) and validates them
  * against the provided schema.
  *
@@ -48,6 +67,7 @@ export function readEnvFile(path?: string): Record<string, string> {
  * @param options.path Path to the `.env` file (defaults to `.env` in cwd).
  * @param options.allowPlaintext When true, fields with `encrypted: true` that have plaintext values emit a warning instead of an error.
  * @param options.keysPath Path to the `.env.keys` file containing ENVGAD_PRIVATE_KEY (default: `.env.keys`).
+ * @param options.override When true, `.env` file values replace variables already set in the real environment (dotenv's `override` semantics). Default: real environment wins.
  * @returns The validated environment variables, typed according to the schema.
  */
 export function loadEnv<S extends SchemaDefinition>(
@@ -59,12 +79,13 @@ export function loadEnv<S extends SchemaDefinition>(
     path?: string;
     allowPlaintext?: boolean;
     keysPath?: string;
+    override?: boolean;
   }
 ): InferEnv<S> {
   const fileEnv = readEnvFile(options?.path);
   // Use runtime-aware environment getter (process.env or Bun.env)
   const runtimeEnv = getEnv();
-  const env = { ...runtimeEnv, ...fileEnv };
+  const env = mergeEnv(fileEnv, runtimeEnv, options?.override);
 
   const validator = new EnvValidator(schema, options);
   return validator.validate(env) as InferEnv<S>;


### PR DESCRIPTION
Fixes #61

Both entry points merged the `.env` file last, so file values silently
overrode variables already set in the real environment:

```js
// loadEnv                          // validateEnv
{ ...runtimeEnv, ...fileEnv }       { ...process.env, ...fileEnv }

This inverts dotenv's convention. With LOG_LEVEL=debug in .env:


$ LOG_LEVEL=error node app.js
loadEnv().LOG_LEVEL  // "debug" — wrong, now "error"
Changes:

New shared mergeEnv(fileEnv, runtimeEnv, override?) helper used by both loadEnv and validateEnv: the real environment wins, the .env file provides defaults. It also ignores undefined runtime entries so they can't clobber file values (a plain spread would).
New override: true option on loadEnv and validateEnv restores the old file-wins behavior explicitly, mirroring dotenv's own override flag.
dotenv-gad check inherits the fix via validateEnv; the file-editing CLI commands (encrypt, status, …) intentionally still operate on the file.
Corrected the usage guide, which documented the inverted precedence, and documented the new override option.
Breaking behavior change: projects relying on .env overriding
shell/CI-injected variables must now pass override: true. Recommend calling
this out in the release notes.

Tests: 9 new tests in __tests__/env-precedence.test.ts (merge semantics plus
loadEnv/validateEnv integration). Full suite passes (210 tests, 17 files);
tsc --noEmit clean.